### PR TITLE
Fix typo in send-gui command

### DIFF
--- a/2.-Command-line-usage.rst
+++ b/2.-Command-line-usage.rst
@@ -205,7 +205,7 @@ table in the interactive interface with the following command:
 
 ::
 
-    oc send-gui test.sqlite
+    oc util send-gui test.sqlite
 
 
 Command line manual 


### PR DESCRIPTION
Fixed minor imprecision, old version missed `util` before `send-gui`, correct usage is:
`oc util send-gui <filename>.sqlite`